### PR TITLE
Allow multiple clients per IP

### DIFF
--- a/main/ip_checker.go
+++ b/main/ip_checker.go
@@ -4,32 +4,65 @@ import (
 	"sync"
 )
 
+const maxPerIP = 5
+
 type banner struct {
-	IPs map[string]int
+	IPs map[string][]int
 	mu  sync.RWMutex
 }
 
 func initBanner() *banner {
 	return &banner{
-		IPs: make(map[string]int),
+		IPs: make(map[string][]int),
 	}
 }
 
-func (b *banner) register(ip string, id int) {
+// register adds a connection for ip. If the ip already has maxPerIP
+// connections, the oldest one is removed and its id returned.
+func (b *banner) register(ip string, id int) (int, bool) {
 	b.mu.Lock()
-	b.IPs[ip] = id
+	defer b.mu.Unlock()
+
+	ids := b.IPs[ip]
+	var removed int
+	var replaced bool
+	if len(ids) >= maxPerIP {
+		removed = ids[0]
+		ids = ids[1:]
+		replaced = true
+	}
+	ids = append(ids, id)
+	b.IPs[ip] = ids
+	return removed, replaced
+}
+
+// disconnect removes the given id from ip connection list.
+func (b *banner) disconnect(ip string, id int) {
+	b.mu.Lock()
+	ids := b.IPs[ip]
+	for i, v := range ids {
+		if v == id {
+			ids = append(ids[:i], ids[i+1:]...)
+			break
+		}
+	}
+	if len(ids) == 0 {
+		delete(b.IPs, ip)
+	} else {
+		b.IPs[ip] = ids
+	}
 	b.mu.Unlock()
 }
 
-func (b *banner) disconnect(ip string) {
-	b.mu.Lock()
-	delete(b.IPs, ip)
-	b.mu.Unlock()
-}
-
-func (b *banner) isConnected(ip string) (int, bool) {
+// overLimit returns the id of a connection to drop if ip already has
+// maxPerIP connections. The returned bool indicates whether a connection
+// should be removed.
+func (b *banner) overLimit(ip string) (int, bool) {
 	b.mu.RLock()
-	v, ok := b.IPs[ip]
+	ids := b.IPs[ip]
 	b.mu.RUnlock()
-	return v, ok
+	if len(ids) >= maxPerIP {
+		return ids[0], true
+	}
+	return 0, false
 }


### PR DESCRIPTION
## Summary
- increase client connection limit per IP from 1 to 5
- track multiple connection ids and cleanup on disconnect

## Testing
- `go build ./...` *(fails: Get proxy.golang.org Forbidden)*
- `go vet ./...` *(fails: Get proxy.golang.org Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c00e703508330abbd7057ffc5016f