### PR TITLE
Add chat timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Front and back communicate through a websocket, each update sends the entire wor
 Sorted by priority:
  * RLE Sharing
  * Smarter zoom on region
- * Add timestamps for messages
  * Show messages once they are downloaded
  * Rename brushes
  * Change eraser size dynamically
@@ -34,4 +33,5 @@ Done:
  * ~Add send button~
  * ~Change /connected endpoint to WS~
  * ~Optimize draw using Uint32~
+ * ~Add timestamps for messages~
  

--- a/data/index.css
+++ b/data/index.css
@@ -179,6 +179,11 @@ h2 {
     background-color: rgba(56, 56, 56, 0.50);
 }
 
+.timestamp {
+    color: gray;
+    margin-right: 5px;
+}
+
 .brush {
     position: relative;
 }

--- a/data/index.js
+++ b/data/index.js
@@ -48,7 +48,9 @@ function initChatroom() {
         }, 1000);
     };
     messageWs.onmessage = function (evt) {
-        messageDiv.innerHTML += `<li class="message">${evt.data}</li>`;
+        let ts = evt.data.substring(0, 14);
+        let content = evt.data.substring(15);
+        messageDiv.innerHTML += `<li class="message"><span class="timestamp">${ts}</span> ${content}</li>`;
         messageDiv.scrollTop = messageDiv.scrollHeight;
     };
     messageWs.onerror = function (evt) {

--- a/messaging/hub.go
+++ b/messaging/hub.go
@@ -59,13 +59,14 @@ func (h *Hub) Run() {
 				close(client.send)
 			}
 		case message := <-h.broadcast:
-			h.history = append(h.history, h.rc.storeMessage(string(message)))
+			tm := h.rc.storeMessage(string(message))
+			h.history = append(h.history, tm)
 
 			for client := range h.clients {
 				// log.Printf("Client room: %s message room: %s \n",
 				// 	client.room, msg.ChatRoomName)
 				select {
-				case client.send <- message:
+				case client.send <- []byte(tm.message):
 				default:
 					close(client.send)
 					delete(h.clients, client)


### PR DESCRIPTION
## Summary
- timestamp chat messages in backend using Go
- show timestamps next to each message in frontend
- style timestamps in CSS
- mark TODO entry as done in README

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f21228ba08330b123c59ba395694a